### PR TITLE
Use context managers to ensure the blob client is properly closed aft…

### DIFF
--- a/plugfs/azure.py
+++ b/plugfs/azure.py
@@ -57,34 +57,41 @@ class AzureStorageBlobsAdapter(Adapter):
 
     async def read(self, path: str) -> bytes:
         blob_client = self._client.get_blob_client(path)
-        try:
-            stream = await blob_client.download_blob()
-        except ResourceNotFoundError as error:
-            raise NotFoundException(f"Failed to find file '{path}'!") from error
 
-        return await stream.readall()
+        async with blob_client:
+            try:
+                stream = await blob_client.download_blob()
+            except ResourceNotFoundError as error:
+                raise NotFoundException(f"Failed to find file '{path}'!") from error
+
+            return await stream.readall()
 
     async def get_file(self, path: str) -> File:
         blob_client = self._client.get_blob_client(path)
-        if await blob_client.exists():
-            return AzureFile(path, self)
+
+        async with blob_client:
+            if await blob_client.exists():
+                return AzureFile(path, self)
 
         raise NotFoundException(f"Failed to find file '{path}'!")
 
     async def write(self, path: str, data: bytes) -> File:
         blob_client = self._client.get_blob_client(path)
 
-        await blob_client.upload_blob(data, overwrite=True)
+        async with blob_client:
+            await blob_client.upload_blob(data, overwrite=True)
 
         return AzureFile(path, self)
 
     async def get_size(self, path: str) -> int:
         blob_client = self._client.get_blob_client(path)
-        try:
-            stream = await blob_client.download_blob()
-        except ResourceNotFoundError as error:
-            raise NotFoundException(f"Failed to find file '{path}'!") from error
 
-        size = cast(int, stream.size)
+        async with blob_client:
+            try:
+                stream = await blob_client.download_blob()
+            except ResourceNotFoundError as error:
+                raise NotFoundException(f"Failed to find file '{path}'!") from error
+
+            size = cast(int, stream.size)
 
         return size


### PR DESCRIPTION
…er use