### PR TITLE
Replace `pytest-asyncio` with `anyio`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -165,6 +165,26 @@ files = [
 frozenlist = ">=1.1.0"
 
 [[package]]
+name = "anyio"
+version = "4.6.0"
+description = "High level compatibility layer for multiple asynchronous event loop implementations"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "anyio-4.6.0-py3-none-any.whl", hash = "sha256:c7d2e9d63e31599eeb636c8c5c03a7e108d73b345f064f1c19fdc87b79036a9a"},
+    {file = "anyio-4.6.0.tar.gz", hash = "sha256:137b4559cbb034c477165047febb6ff83f390fc3b20bf181c1fc0a728cb8beeb"},
+]
+
+[package.dependencies]
+idna = ">=2.8"
+sniffio = ">=1.1"
+
+[package.extras]
+doc = ["Sphinx (>=7.4,<8.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
+test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "uvloop (>=0.21.0b1)"]
+trio = ["trio (>=0.26.1)"]
+
+[[package]]
 name = "attrs"
 version = "23.2.0"
 description = "Classes Without Boilerplate"
@@ -1152,24 +1172,6 @@ pluggy = ">=1.5,<2"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
-name = "pytest-asyncio"
-version = "0.24.0"
-description = "Pytest support for asyncio"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pytest_asyncio-0.24.0-py3-none-any.whl", hash = "sha256:a811296ed596b69bf0b6f3dc40f83bcaf341b155a269052d82efa2b25ac7037b"},
-    {file = "pytest_asyncio-0.24.0.tar.gz", hash = "sha256:d081d828e576d85f875399194281e92bf8a68d60d72d1a2faf2feddb6c46b276"},
-]
-
-[package.dependencies]
-pytest = ">=8.2,<9"
-
-[package.extras]
-docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
-testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
-
-[[package]]
 name = "pytest-cov"
 version = "5.0.0"
 description = "Pytest plugin for measuring coverage."
@@ -1217,6 +1219,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 files = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+description = "Sniff out which async library your code is running under"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
 ]
 
 [[package]]
@@ -1364,4 +1377,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "090c053f5898eef23618088ea70525b37ad9baa9f1e78e749a2b73caefe693d1"
+content-hash = "87cd00e35d04e417fe3202b5940641e4431737525902ee9715b44c2e418f7856"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,11 @@ aiohttp = {extras = ["speedups"], version = "^3.10.5"}
 azure-storage-blob = "^12.23.0"
 
 [tool.poetry.group.dev.dependencies]
+anyio = "^4.6.0"
 black = "^24.8.0"
 isort = "^5.13.2"
 mypy = "^1.11.2"
 pytest = "^8.3.3"
-pytest-asyncio = "^0.24.0"
 pytest-cov = "^5.0.0"
 types-aiofiles = "^24.1.0.20240626"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -2,7 +2,6 @@ import os
 from typing import AsyncGenerator
 
 import pytest
-import pytest_asyncio
 from azure.core.exceptions import ResourceNotFoundError
 from azure.storage.blob.aio import ContainerClient
 
@@ -10,7 +9,7 @@ from plugfs.azure import AzureFile, AzureStorageBlobsAdapter
 from plugfs.filesystem import Directory, NotFoundException
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def container_client() -> AsyncGenerator[ContainerClient, None]:
     client = ContainerClient.from_connection_string(
         f"DefaultEndpointsProtocol=http;AccountName={os.getenv("AZURE_ACCOUNT_NAME")};"
@@ -71,7 +70,7 @@ def azure_storage_blobs_adapter(
 
 
 class TestAzureStorageBlobsAdapter:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_list_root(
         self, azure_storage_blobs_adapter: AzureStorageBlobsAdapter
     ) -> None:
@@ -86,7 +85,7 @@ class TestAzureStorageBlobsAdapter:
         assert isinstance(items[1], Directory)
         assert items[1].path == "/directory"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_list_directory(
         self, azure_storage_blobs_adapter: AzureStorageBlobsAdapter
     ) -> None:
@@ -100,7 +99,7 @@ class TestAzureStorageBlobsAdapter:
         assert isinstance(items[1], Directory)
         assert items[1].path == "/directory/subdirectory"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_list_subdirectory(
         self, azure_storage_blobs_adapter: AzureStorageBlobsAdapter
     ) -> None:
@@ -111,14 +110,14 @@ class TestAzureStorageBlobsAdapter:
         assert isinstance(items[0], AzureFile)
         assert items[0].path == "/directory/subdirectory/nested_file"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_list_non_existing(
         self, azure_storage_blobs_adapter: AzureStorageBlobsAdapter
     ) -> None:
         items = await azure_storage_blobs_adapter.list("/this/path/does/not/exist")
         assert len(items) == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_read(
         self, azure_storage_blobs_adapter: AzureStorageBlobsAdapter
     ) -> None:
@@ -126,7 +125,7 @@ class TestAzureStorageBlobsAdapter:
 
         assert len(data) == 1048576
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_read_non_existing(
         self, azure_storage_blobs_adapter: AzureStorageBlobsAdapter
     ) -> None:
@@ -138,7 +137,7 @@ class TestAzureStorageBlobsAdapter:
             == "Failed to find file '/this/path/does/not/exist'!"
         )
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_file(
         self, azure_storage_blobs_adapter: AzureStorageBlobsAdapter
     ) -> None:
@@ -146,7 +145,7 @@ class TestAzureStorageBlobsAdapter:
 
         assert isinstance(file, AzureFile)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_file_non_existing(
         self, azure_storage_blobs_adapter: AzureStorageBlobsAdapter
     ) -> None:
@@ -158,7 +157,7 @@ class TestAzureStorageBlobsAdapter:
             == "Failed to find file '/this/path/does/not/exist'!"
         )
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_write_new(
         self, azure_storage_blobs_adapter: AzureStorageBlobsAdapter
     ) -> None:
@@ -166,7 +165,7 @@ class TestAzureStorageBlobsAdapter:
 
         assert await file.size == 12
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_write_overwrite_existing(
         self, azure_storage_blobs_adapter: AzureStorageBlobsAdapter
     ) -> None:

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -9,7 +9,7 @@ from plugfs.local import LocalAdapter, LocalFile
 
 
 class TestLocalAdapter:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_list(self) -> None:
         adapter = LocalAdapter()
         items = await adapter.list(path.join(path.dirname(__file__), "resources"))
@@ -32,7 +32,7 @@ class TestLocalAdapter:
                 directory_found = True
         assert file_found is True and directory_found is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_list_non_existing(self) -> None:
         adapter = LocalAdapter()
         with pytest.raises(NotFoundException) as exception_info:
@@ -43,7 +43,7 @@ class TestLocalAdapter:
             == "Failed to retrieve directory listing for '/this/path/does/not/exist'!"
         )
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_read(self) -> None:
         adapter = LocalAdapter()
 
@@ -53,7 +53,7 @@ class TestLocalAdapter:
 
         assert len(data) == 1048576
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_read_non_existing(self) -> None:
         adapter = LocalAdapter()
 
@@ -65,7 +65,7 @@ class TestLocalAdapter:
             == "Failed to find file '/this/path/does/not/exist'!"
         )
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_file(self) -> None:
         adapter = LocalAdapter()
 
@@ -75,7 +75,7 @@ class TestLocalAdapter:
 
         assert isinstance(file, LocalFile)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_file_non_existing(self) -> None:
         adapter = LocalAdapter()
 
@@ -87,7 +87,7 @@ class TestLocalAdapter:
             == "Failed to find file '/this/path/does/not/exist'!"
         )
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_write_new(self) -> None:
         adapter = LocalAdapter()
         filepath = path.join("/tmp", str(uuid4()))
@@ -97,7 +97,7 @@ class TestLocalAdapter:
 
         os.remove(filepath)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_write_overwrite_existing(self) -> None:
         adapter = LocalAdapter()
         filepath = path.join("/tmp", str(uuid4()))
@@ -109,7 +109,7 @@ class TestLocalAdapter:
 
         os.remove(filepath)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_write_non_existing_directory(self) -> None:
         adapter = LocalAdapter()
 
@@ -121,7 +121,7 @@ class TestLocalAdapter:
             == "Failed to write file '/this/path/does/not/exist', directory does not exist!"
         )
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_makedirs(self) -> None:
         adapter = LocalAdapter()
         dir_path = path.join("/tmp", str(uuid4()))


### PR DESCRIPTION
The asyncio plugin was giving deprecation warnings and is not great with handling different fixture scopes.
We're migrating all of our projects that use it to anyio, which is easier to use.